### PR TITLE
Make linting a separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,18 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: deps
         run: make dev
-      - name: lint
-        run: make lint
       - name: test
         run: make test
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: deps
+        run: make dev
+      - name: lint
+        run: make lint
+
   # TODO: Enable once CLI development begins.
   # check-readme:
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
We don't need to run this for every Python version.