### PR TITLE
Support multiple issuers and alternative proofs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
             "mypy",
             "types-cryptography",
             "types-requests",
+            "types-pyjwt",
         ]
     },
     classifiers=[

--- a/sigstore/_internal/fulcio/_client.py
+++ b/sigstore/_internal/fulcio/_client.py
@@ -70,7 +70,7 @@ class FulcioCertificateSigningRequest:
     """Certificate request"""
 
     public_key: ec.EllipticCurvePublicKey
-    signed_email_address: bytes
+    signed_proof: bytes
 
     @property
     def data(self) -> str:
@@ -82,7 +82,7 @@ class FulcioCertificateSigningRequest:
             "publicKey": {
                 "content": base64.b64encode(content).decode(),
             },
-            "signedEmailAddress": base64.b64encode(self.signed_email_address).decode(),
+            "signedEmailAddress": base64.b64encode(self.signed_proof).decode(),
         }
         return json.dumps(data)
 

--- a/sigstore/_internal/oidc.py
+++ b/sigstore/_internal/oidc.py
@@ -1,0 +1,48 @@
+import jwt
+
+# From https://github.com/sigstore/fulcio/blob/b2186c01da1ddf807bde3ea8c450226d8e001d88/pkg/config/config.go#L182-L201  # noqa
+OIDC_ISSUERS = {
+    "https://accounts.google.com": {
+        "proof_claim": "email",
+    },
+    "https://oauth2.sigstore.dev/auth": {
+        "proof_claim": "email",
+    },
+    "https://token.actions.githubusercontent.com": {
+        "proof_claim": "sub",
+    },
+}
+AUDIENCE = "sigstore"
+
+
+class IdentityError(Exception):
+    pass
+
+
+class Identity:
+    def __init__(self, identity_token):
+        identity_jwt = jwt.decode(identity_token, options={"verify_signature": False})
+
+        if "iss" not in identity_jwt:
+            raise IdentityError("Identity token  missing the required 'iss' claim")
+
+        iss = identity_jwt.get("iss")
+
+        if iss not in OIDC_ISSUERS:
+            raise IdentityError(f"Not a valid OIDC issuer: {iss!r}")
+
+        if "aud" not in identity_jwt:
+            raise IdentityError("Identity token missing the required 'aud' claim")
+
+        aud = identity_jwt.get("aud")
+
+        if aud != AUDIENCE:
+            raise IdentityError(f"Audience should be {AUDIENCE!r}, not {aud!r}")
+
+        proof_claim = OIDC_ISSUERS[iss]["proof_claim"]
+        if proof_claim not in identity_jwt:
+            raise IdentityError(
+                f"Identity token missing the required {proof_claim!r} claim"
+            )
+
+        self.proof = identity_jwt.get(proof_claim)

--- a/sigstore/_internal/oidc.py
+++ b/sigstore/_internal/oidc.py
@@ -20,7 +20,7 @@ class IdentityError(Exception):
 
 
 class Identity:
-    def __init__(self, identity_token):
+    def __init__(self, identity_token: str) -> None:
         identity_jwt = jwt.decode(identity_token, options={"verify_signature": False})
 
         if "iss" not in identity_jwt:

--- a/sigstore/_internal/oidc.py
+++ b/sigstore/_internal/oidc.py
@@ -2,15 +2,9 @@ import jwt
 
 # From https://github.com/sigstore/fulcio/blob/b2186c01da1ddf807bde3ea8c450226d8e001d88/pkg/config/config.go#L182-L201  # noqa
 OIDC_ISSUERS = {
-    "https://accounts.google.com": {
-        "proof_claim": "email",
-    },
-    "https://oauth2.sigstore.dev/auth": {
-        "proof_claim": "email",
-    },
-    "https://token.actions.githubusercontent.com": {
-        "proof_claim": "sub",
-    },
+    "https://accounts.google.com": "email",
+    "https://oauth2.sigstore.dev/auth": "email",
+    "https://token.actions.githubusercontent.com": "sub",
 }
 AUDIENCE = "sigstore"
 
@@ -39,7 +33,7 @@ class Identity:
         if aud != AUDIENCE:
             raise IdentityError(f"Audience should be {AUDIENCE!r}, not {aud!r}")
 
-        proof_claim = OIDC_ISSUERS[iss]["proof_claim"]
+        proof_claim = OIDC_ISSUERS[iss]
         if proof_claim not in identity_jwt:
             raise IdentityError(
                 f"Identity token missing the required {proof_claim!r} claim"


### PR DESCRIPTION
This PR provides an `Identity` class which supports all the OIDC issuers Fulcio currently supports, as well as determine alternative proofs (e.g. using the `subject` claim instead of `email` for GitHub Actions)

Fixes #17.